### PR TITLE
Fix shellcheck SC2154 warnings for selected_file variable

### DIFF
--- a/list-a-org-nodes.sh
+++ b/list-a-org-nodes.sh
@@ -67,6 +67,7 @@ source "${SCRIPT_DIR}/lib/common.sh"
 setup_cleanup_trap
 
 # Handle .env file selection and load credentials
+selected_file=""  # Will be set by select_env_file
 select_env_file "$ENV_FILE" || exit 1
 load_credentials "$selected_file" || exit 1
 

--- a/list-a-orgs.sh
+++ b/list-a-orgs.sh
@@ -69,6 +69,7 @@ setup_cleanup_trap
 
 # Handle .env file selection
 # Handle .env file selection and load credentials
+selected_file=""  # Will be set by select_env_file
 select_env_file "$ENV_FILE" || exit 1
 load_credentials "$selected_file" || exit 1
 

--- a/list-a-user-deployment.sh
+++ b/list-a-user-deployment.sh
@@ -81,6 +81,7 @@ source "${SCRIPT_DIR}/lib/common.sh"
 setup_cleanup_trap
 
 # Handle .env file selection and load credentials
+selected_file=""  # Will be set by select_env_file
 select_env_file "$ENV_FILE" || exit 1
 load_credentials "$selected_file" || exit 1
 

--- a/list-a-user-nodes.sh
+++ b/list-a-user-nodes.sh
@@ -81,6 +81,7 @@ source "${SCRIPT_DIR}/lib/common.sh"
 setup_cleanup_trap
 
 # Handle .env file selection and load credentials
+selected_file=""  # Will be set by select_env_file
 select_env_file "$ENV_FILE" || exit 1
 load_credentials "$selected_file" || exit 1
 

--- a/list-a-user-services.sh
+++ b/list-a-user-services.sh
@@ -81,6 +81,7 @@ source "${SCRIPT_DIR}/lib/common.sh"
 setup_cleanup_trap
 
 # Handle .env file selection and load credentials
+selected_file=""  # Will be set by select_env_file
 select_env_file "$ENV_FILE" || exit 1
 load_credentials "$selected_file" || exit 1
 

--- a/list-a-users.sh
+++ b/list-a-users.sh
@@ -68,6 +68,7 @@ source "${SCRIPT_DIR}/lib/common.sh"
 setup_cleanup_trap
 
 # Handle .env file selection and load credentials
+selected_file=""  # Will be set by select_env_file
 select_env_file "$ENV_FILE" || exit 1
 load_credentials "$selected_file" || exit 1
 

--- a/list-orgs.sh
+++ b/list-orgs.sh
@@ -56,6 +56,7 @@ done
 setup_cleanup_trap
 
 # Select and load credentials
+selected_file=""  # Will be set by select_env_file
 select_env_file "$ENV_FILE_ARG" || exit 1
 load_credentials "$selected_file" || exit 1
 

--- a/list-users.sh
+++ b/list-users.sh
@@ -34,6 +34,7 @@ fi
 # Only prompt for .env file selection if credentials are not already set
 if [ "$SKIP_ENV_SELECTION" = false ]; then
     # shellcheck disable=SC2119  # Function doesn't use positional parameters
+    selected_file=""  # Will be set by select_env_file
     select_env_file || exit 1
     load_credentials "$selected_file" || exit 1
 fi

--- a/test-credentials.sh
+++ b/test-credentials.sh
@@ -16,6 +16,7 @@ setup_cleanup_trap
 
 # Select and load credentials
 # shellcheck disable=SC2119  # Function doesn't use positional parameters
+selected_file=""  # Will be set by select_env_file
 select_env_file || exit 1
 load_credentials "$selected_file" || exit 1
 


### PR DESCRIPTION
## Summary
Fixes all shellcheck SC2154 warnings by declaring the `selected_file` variable before it's used in scripts.

## Problem
Shellcheck was reporting SC2154 warnings in 9 scripts:
- `selected_file is referenced but not assigned`

The variable is set by the `select_env_file` function in `lib/common.sh`, but shellcheck doesn't recognize this when analyzing scripts that source the library.

## Solution
Added `selected_file=""` declaration with comment `# Will be set by select_env_file` before each call to `select_env_file` in all affected scripts.

## Files Changed
- list-users.sh
- list-a-orgs.sh
- test-credentials.sh
- list-a-users.sh
- list-a-user-nodes.sh
- list-a-user-deployment.sh
- list-a-org-nodes.sh
- list-orgs.sh
- list-a-user-services.sh

## Testing
The GitHub Actions shellcheck workflow should now pass without warnings.