### PR TITLE
Issue #3: Fix false failure report for unconfigured node warning

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -357,7 +357,7 @@ setup_cleanup_trap() {
         }
     fi
     
-    trap '$cleanup_func' EXIT INT TERM
+    trap "$cleanup_func" EXIT INT TERM
 }
 
 # Export functions and variables for use in other scripts

--- a/test-hzn.sh
+++ b/test-hzn.sh
@@ -133,7 +133,6 @@ if [ $exit_code -eq 0 ]; then
         echo ""
         echo "Or use a pattern:"
         echo "  hzn register -o <org-id> -u <user>:<password> -p <pattern-name>"
-        all_checks_passed=false
     elif [ "$config_state" = "configured" ]; then
         print_success "Node is configured"
     else


### PR DESCRIPTION
## Summary

- Fixes false "Some checks FAILED" report when node is unconfigured
- An unconfigured node now correctly shows a warning but reports overall success
- Includes minor fix to `lib/common.sh` trap command quoting

## Problem

When running `test-hzn.sh` with valid credentials on an unconfigured node, the script reported "Some checks FAILED" even though no checks actually failed. The unconfigured node state was being treated as a failure instead of an informational warning.

## Solution

Removed `all_checks_passed=false` from line 136 in `test-hzn.sh`. This line was incorrectly setting the failure flag after displaying a warning (not an error) about the unconfigured node state.

## Test plan

- [x] Run `test-hzn.sh` with credentials for an unconfigured node
- [x] Verify warning "⚠ Node is unconfigured" still appears
- [x] Verify summary now shows "✓ All checks PASSED!"
- [x] Verify script syntax with `bash -n test-hzn.sh`

Closes #3