### PR TITLE
Issue 7: Add -k flag to all curl commands for SSL consistency

### DIFF
--- a/list-a-org-nodes.sh
+++ b/list-a-org-nodes.sh
@@ -95,7 +95,7 @@ fi
 
 # Make the API call to get all nodes in the organization
 # API endpoint: /orgs/{orgid}/nodes
-response=$(curl -sS -w "\n%{http_code}" -u "$FULL_AUTH" "${BASE_URL}/orgs/${HZN_ORG_ID}/nodes" 2>&1)
+response=$(curl -sS -k -w "\n%{http_code}" -u "$FULL_AUTH" "${BASE_URL}/orgs/${HZN_ORG_ID}/nodes" 2>&1)
 
 # Extract HTTP status code (last line)
 http_code=$(echo "$response" | tail -n1)

--- a/list-a-orgs.sh
+++ b/list-a-orgs.sh
@@ -97,7 +97,7 @@ fi
 
 # Make the API call
 # Note: HZN_EXCHANGE_URL should already include the API version (e.g., /v1)
-response=$(curl -sS -w "\n%{http_code}" -u "$FULL_AUTH" "${BASE_URL}/orgs" 2>&1)
+response=$(curl -sS -k -w "\n%{http_code}" -u "$FULL_AUTH" "${BASE_URL}/orgs" 2>&1)
 
 # Extract HTTP status code (last line)
 http_code=$(echo "$response" | tail -n1)
@@ -178,7 +178,7 @@ if [ "$JSON_ONLY" = false ]; then
     # Test access to each organization
     for org in "${org_names[@]}"; do
         # Try to get detailed info for each org
-        org_response=$(curl -sS -w "\n%{http_code}" -u "$FULL_AUTH" "${BASE_URL}/orgs/${org}" 2>&1)
+        org_response=$(curl -sS -k -w "\n%{http_code}" -u "$FULL_AUTH" "${BASE_URL}/orgs/${org}" 2>&1)
         org_http_code=$(echo "$org_response" | tail -n1)
         
         if [ "$org_http_code" -eq 200 ]; then

--- a/list-a-user-deployment.sh
+++ b/list-a-user-deployment.sh
@@ -144,7 +144,7 @@ fi
 # Make the API call to get deployment policies owned by the user
 # API endpoint: /orgs/{orgid}/business/policies?owner={org/userid}
 # Note: The owner parameter must be in org/user format
-response=$(curl -sS -w "\n%{http_code}" -u "$FULL_AUTH" "${BASE_URL}/orgs/${HZN_ORG_ID}/business/policies?owner=${OWNER_ID}" 2>&1)
+response=$(curl -sS -k -w "\n%{http_code}" -u "$FULL_AUTH" "${BASE_URL}/orgs/${HZN_ORG_ID}/business/policies?owner=${OWNER_ID}" 2>&1)
 
 # Extract HTTP status code (last line)
 http_code=$(echo "$response" | tail -n1)

--- a/list-a-user-nodes.sh
+++ b/list-a-user-nodes.sh
@@ -144,7 +144,7 @@ fi
 # Make the API call to get nodes owned by the user
 # API endpoint: /orgs/{orgid}/nodes?owner={org/userid}
 # Note: The owner parameter must be in org/user format
-response=$(curl -sS -w "\n%{http_code}" -u "$FULL_AUTH" "${BASE_URL}/orgs/${HZN_ORG_ID}/nodes?owner=${OWNER_ID}" 2>&1)
+response=$(curl -sS -k -w "\n%{http_code}" -u "$FULL_AUTH" "${BASE_URL}/orgs/${HZN_ORG_ID}/nodes?owner=${OWNER_ID}" 2>&1)
 
 # Extract HTTP status code (last line)
 http_code=$(echo "$response" | tail -n1)

--- a/list-a-user-services.sh
+++ b/list-a-user-services.sh
@@ -144,7 +144,7 @@ fi
 # Make the API call to get services owned by the user
 # API endpoint: /orgs/{orgid}/services?owner={org/userid}
 # Note: The owner parameter must be in org/user format
-response=$(curl -sS -w "\n%{http_code}" -u "$FULL_AUTH" "${BASE_URL}/orgs/${HZN_ORG_ID}/services?owner=${OWNER_ID}" 2>&1)
+response=$(curl -sS -k -w "\n%{http_code}" -u "$FULL_AUTH" "${BASE_URL}/orgs/${HZN_ORG_ID}/services?owner=${OWNER_ID}" 2>&1)
 
 # Extract HTTP status code (last line)
 http_code=$(echo "$response" | tail -n1)

--- a/list-a-users.sh
+++ b/list-a-users.sh
@@ -96,7 +96,7 @@ fi
 
 # Make the API call
 # Note: HZN_EXCHANGE_URL should already include the API version (e.g., /v1)
-response=$(curl -sS -w "\n%{http_code}" -u "$FULL_AUTH" "${BASE_URL}/orgs/${HZN_ORG_ID}/users" 2>&1)
+response=$(curl -sS -k -w "\n%{http_code}" -u "$FULL_AUTH" "${BASE_URL}/orgs/${HZN_ORG_ID}/users" 2>&1)
 
 # Extract HTTP status code (last line)
 http_code=$(echo "$response" | tail -n1)


### PR DESCRIPTION
## Summary
- Add the `-k` (insecure) flag to all curl commands that were missing it
- Ensures consistent behavior when connecting to Open Horizon instances with self-signed certificates
- Aligns all API-based scripts with the existing pattern in `list-a-user.sh` and `lib/common.sh`

## Changes
Updated 6 files with 7 curl commands:
- `list-a-users.sh`
- `list-a-user-services.sh`
- `list-a-user-nodes.sh`
- `list-a-user-deployment.sh`
- `list-a-orgs.sh` (2 curl commands)
- `list-a-org-nodes.sh`

## Test plan
- [ ] Verify scripts work against Open Horizon instance with self-signed certificate
- [ ] Verify scripts still work against instances with valid certificates

Closes #7