### PR TITLE
Issue 9: Fix ShellCheck SC2064 warning in setup_cleanup_trap

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -357,6 +357,7 @@ setup_cleanup_trap() {
         }
     fi
     
+    # shellcheck disable=SC2064  # Intentional: expand cleanup_func now, not at signal time
     trap "$cleanup_func" EXIT INT TERM
 }
 


### PR DESCRIPTION
## Summary
- Add shellcheck disable directive for SC2064 warning in `lib/common.sh`
- The double-quoted variable expansion is intentional behavior
- Fixes CI failures in ShellCheck and Lint and Format Check jobs

## Changes
Added comment to line 360 in `lib/common.sh`:
```bash
# shellcheck disable=SC2064  # Intentional: expand cleanup_func now, not at signal time
trap "$cleanup_func" EXIT INT TERM
```

## Test plan
- [ ] Verify ShellCheck CI check passes
- [ ] Verify Lint and Format Check CI check passes
- [ ] Verify scripts still function correctly with trap cleanup

Closes #9