### PR TITLE
Issue #16: Add color-coded API request display in verbose mode

### DIFF
--- a/can-i-list-orgs.sh
+++ b/can-i-list-orgs.sh
@@ -120,6 +120,9 @@ if [ "$JSON_ONLY" = false ]; then
     echo ""
 fi
 
+# Display the API request in verbose mode
+display_api_request "GET" "${BASE_URL}/orgs/${HZN_ORG_ID}/users/${AUTH_USER}"
+
 # Fetch current user info
 user_response=$(curl -sS -k -w "\n%{http_code}" -u "$FULL_AUTH" "${BASE_URL}/orgs/${HZN_ORG_ID}/users/${AUTH_USER}" 2>&1)
 user_http_code=$(echo "$user_response" | tail -n1)

--- a/can-i-list-users.sh
+++ b/can-i-list-users.sh
@@ -138,6 +138,9 @@ if [ "$JSON_ONLY" = false ]; then
     echo ""
 fi
 
+# Display the API request in verbose mode
+display_api_request "GET" "${BASE_URL}/orgs/${HZN_ORG_ID}/users/${AUTH_USER}"
+
 # Fetch current user info
 user_response=$(curl -sS -k -w "\n%{http_code}" -u "$FULL_AUTH" "${BASE_URL}/orgs/${HZN_ORG_ID}/users/${AUTH_USER}" 2>&1)
 user_http_code=$(echo "$user_response" | tail -n1)

--- a/list-a-org-nodes.sh
+++ b/list-a-org-nodes.sh
@@ -93,6 +93,9 @@ if [ "$JSON_ONLY" = false ]; then
     echo ""
 fi
 
+# Display the API request in verbose mode
+display_api_request "GET" "${BASE_URL}/orgs/${HZN_ORG_ID}/nodes"
+
 # Make the API call to get all nodes in the organization
 # API endpoint: /orgs/{orgid}/nodes
 response=$(curl -sS -k -w "\n%{http_code}" -u "$FULL_AUTH" "${BASE_URL}/orgs/${HZN_ORG_ID}/nodes" 2>&1)

--- a/list-a-orgs.sh
+++ b/list-a-orgs.sh
@@ -95,6 +95,9 @@ if [ "$JSON_ONLY" = false ]; then
     echo ""
 fi
 
+# Display the API request in verbose mode
+display_api_request "GET" "${BASE_URL}/orgs"
+
 # Make the API call
 # Note: HZN_EXCHANGE_URL should already include the API version (e.g., /v1)
 response=$(curl -sS -k -w "\n%{http_code}" -u "$FULL_AUTH" "${BASE_URL}/orgs" 2>&1)
@@ -177,6 +180,9 @@ if [ "$JSON_ONLY" = false ]; then
 
     # Test access to each organization
     for org in "${org_names[@]}"; do
+        # Display the API request in verbose mode
+        display_api_request "GET" "${BASE_URL}/orgs/${org}"
+        
         # Try to get detailed info for each org
         org_response=$(curl -sS -k -w "\n%{http_code}" -u "$FULL_AUTH" "${BASE_URL}/orgs/${org}" 2>&1)
         org_http_code=$(echo "$org_response" | tail -n1)

--- a/list-a-user-deployment.sh
+++ b/list-a-user-deployment.sh
@@ -141,6 +141,9 @@ if [ "$JSON_ONLY" = false ]; then
     echo ""
 fi
 
+# Display the API request in verbose mode
+display_api_request "GET" "${BASE_URL}/orgs/${HZN_ORG_ID}/business/policies?owner=${OWNER_ID}"
+
 # Make the API call to get deployment policies owned by the user
 # API endpoint: /orgs/{orgid}/business/policies?owner={org/userid}
 # Note: The owner parameter must be in org/user format

--- a/list-a-user-nodes.sh
+++ b/list-a-user-nodes.sh
@@ -141,6 +141,9 @@ if [ "$JSON_ONLY" = false ]; then
     echo ""
 fi
 
+# Display the API request in verbose mode
+display_api_request "GET" "${BASE_URL}/orgs/${HZN_ORG_ID}/nodes?owner=${OWNER_ID}"
+
 # Make the API call to get nodes owned by the user
 # API endpoint: /orgs/{orgid}/nodes?owner={org/userid}
 # Note: The owner parameter must be in org/user format

--- a/list-a-user-services.sh
+++ b/list-a-user-services.sh
@@ -141,6 +141,9 @@ if [ "$JSON_ONLY" = false ]; then
     echo ""
 fi
 
+# Display the API request in verbose mode
+display_api_request "GET" "${BASE_URL}/orgs/${HZN_ORG_ID}/services?owner=${OWNER_ID}"
+
 # Make the API call to get services owned by the user
 # API endpoint: /orgs/{orgid}/services?owner={org/userid}
 # Note: The owner parameter must be in org/user format

--- a/list-a-user.sh
+++ b/list-a-user.sh
@@ -93,6 +93,9 @@ if [ "$JSON_ONLY" = false ]; then
     echo ""
 fi
 
+# Display the API request in verbose mode
+display_api_request "GET" "${BASE_URL}/orgs/${HZN_ORG_ID}/users/${AUTH_USER}"
+
 # Make the API call to get the specific user
 # The endpoint is /orgs/{org}/users/{username}
 # Using -k to allow self-signed certificates (common in Open Horizon deployments)

--- a/list-a-users.sh
+++ b/list-a-users.sh
@@ -94,6 +94,9 @@ if [ "$JSON_ONLY" = false ]; then
     echo ""
 fi
 
+# Display the API request in verbose mode
+display_api_request "GET" "${BASE_URL}/orgs/${HZN_ORG_ID}/users"
+
 # Make the API call
 # Note: HZN_EXCHANGE_URL should already include the API version (e.g., /v1)
 response=$(curl -sS -k -w "\n%{http_code}" -u "$FULL_AUTH" "${BASE_URL}/orgs/${HZN_ORG_ID}/users" 2>&1)


### PR DESCRIPTION
## Summary
This PR adds color-coded API request display in verbose mode for all API-based scripts.

## Changes
- Created `display_api_request()` function in `lib/common.sh`
- Shows formatted request details before API responses when `--verbose` flag is used
- Color-codes URL components for easy identification:
  - **GREEN**: Base URL
  - **YELLOW**: HTTP method and Organization IDs
  - **MAGENTA**: Usernames
  - **BLUE**: Resource types (nodes, services, business/policies, apikey)
  - **CYAN**: Query parameters and request body
  - **RED**: Masked passwords (shown as \*\*\*\*\*\*\*\*)
- Updated all API-calling functions and scripts to use new display
- Maintains backward compatibility with non-verbose mode

## Testing
✓ All scripts pass syntax validation
✓ Color-coded output displays correctly
✓ Request details show before API responses in verbose mode
✓ Non-verbose mode remains unchanged

## Related Issue
Closes #16